### PR TITLE
Improve createHourlyGranular performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - composer self-update
   - composer install --prefer-source --no-interaction --dev
 
-script: phpunit
+script: ./vendor/bin/phpunit
 
 notifications:
   slack: roomify:CZvo6Wik7hwNEr055RRLud9j

--- a/src/Event/EventItemizer.php
+++ b/src/Event/EventItemizer.php
@@ -292,6 +292,7 @@ class EventItemizer {
       if ($min == 60 && $start_minute !== 0) {
         // Not a real hour - leave as is and move on
         $min = 0;
+        $hour++;
         $start_minute = 0;
       }
       elseif ($min == 60 && $start_minute == 0) {

--- a/src/Event/EventItemizer.php
+++ b/src/Event/EventItemizer.php
@@ -303,7 +303,7 @@ class EventItemizer {
         $start_minute = 0;
       }
 
-      if ($hour == 23 && $min == 60) {
+      if ($hour == 24) {
         // Re-calculate if we're at a day boundary.
         $init = TRUE;
       }

--- a/src/Event/EventItemizer.php
+++ b/src/Event/EventItemizer.php
@@ -266,8 +266,7 @@ class EventItemizer {
   public function createHourlyGranular(\DatePeriod $period, \DateTime $period_start) {
     $itemized = array();
 
-    $counter = (int)$period_start->format('i');
-    $start_minute = $counter;
+    $start_minute = (int)$period_start->format('i');
     $init = TRUE;
 
     $event_value = $this->event->getValue();


### PR DESCRIPTION
The repeated calls to DateTime->format() were fairly inefficient - I was able to cut the time spent in this method from 5+ seconds to just over 1 on a search with ~360 units. Please have a look, thanks :)