### PR TITLE
Fill in gaps when events are split.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All Notable changes to BAT will be documented in this file
 - Nothing
 
 ### Fixed
-- Nothing
+- The event stores now ensure new events splitting existing events do not leave empty gaps between day boundaries and the new event.
 
 ### Removed
 - Nothing

--- a/src/Calendar/AbstractCalendar.php
+++ b/src/Calendar/AbstractCalendar.php
@@ -30,7 +30,7 @@ abstract class AbstractCalendar implements CalendarInterface {
   /**
    * The class that will access the actual event store where event data is held.
    *
-   * @var
+   * @var \Roomify\Bat\Store\StoreInterface
    */
   protected $store;
 

--- a/src/Calendar/CalendarInterface.php
+++ b/src/Calendar/CalendarInterface.php
@@ -23,7 +23,7 @@ interface CalendarInterface {
    * @param $end_date
    * The end date of our range
    *
-   * @return EventInterface[]
+   * @return \Roomify\Bat\Event\EventInterface[]
    * An array of Event objects
    */
   public function getEvents(\DateTime $start_date, \DateTime $end_date);
@@ -31,10 +31,10 @@ interface CalendarInterface {
   /**
    * Given an array of Events the calendar is updated with the relevant data.
    *
-   * @param EventInterface[] $events
+   * @param \Roomify\Bat\Event\EventInterface[] $events
    *   An array of events to update the calendar with
    *
-   * @param granularity
+   * @param $granularity
    *  The leverl of detail (one of HOURLY, DAILY) at which to store the event
    */
   public function addEvents($events, $granularity);

--- a/src/Event/AbstractEvent.php
+++ b/src/Event/AbstractEvent.php
@@ -10,6 +10,7 @@ namespace Roomify\Bat\Event;
 use Roomify\Bat\Event\EventInterface;
 use Roomify\Bat\Store\Store;
 use Roomify\Bat\EventFormatter\EventFormatter;
+use Roomify\Bat\Store\StoreInterface;
 
 abstract class AbstractEvent implements EventInterface {
 
@@ -466,12 +467,12 @@ abstract class AbstractEvent implements EventInterface {
   /**
    * Saves an event using the Store object
    *
-   * @param Store $store
+   * @param StoreInterface $store
    * @param string $granularity
    *
    * @return boolean
    */
-  public function saveEvent(Store $store, $granularity = AbstractEvent::BAT_HOURLY) {
+  public function saveEvent(StoreInterface $store, $granularity = AbstractEvent::BAT_HOURLY) {
     return $store->storeEvent($this, $granularity);
   }
 

--- a/src/Store/Store.php
+++ b/src/Store/Store.php
@@ -7,11 +7,86 @@
 
 namespace Roomify\Bat\Store;
 
-use Roomify\Bat\Store\StoreInterface;
+use Roomify\Bat\Event\Event;
 
 /**
  * The basic Store class
  */
 abstract class Store implements StoreInterface {
+
+  /**
+   * Fill in hourly values from existing events when a day is being split.
+   *
+   * $existing_events must contain an existing event for the unit the same day.
+   * This only needs to be called for hourly granularity.
+   *
+   * @param array $existing_events
+   *   Existing event data from ::getEventData().
+   * @param array $itemized
+   *   The new event itemized. Values from existing overlapping events will be
+   *   inserted into it.
+   * @param int $value
+   *   The value of the event being added.
+   * @param int $unit_id
+   *   The unit the event being added.
+   * @param int $year
+   *   Year of the event.
+   * @param int $month
+   *   A month of the event.
+   * @param int $day
+   *   Day of the event.
+   */
+  protected function itemizeSplitDay(array &$existing_events, array &$itemized, $value, $unit_id, $year, $month, $day) {
+    $existing_value = $existing_events[$unit_id][EVENT::BAT_DAY][$year][$month][$day];
+    if ($value === -1 && $existing_value > 0) {
+      $itemized_day = &$itemized[Event::BAT_HOUR][$year][$month][$day];
+      for ($hour = 0; $hour < 24; $hour++) {
+        $hour_key = 'h' . $hour;
+        $var = &$itemized_day[$hour_key];
+        $var = isset($var) && $var != 0 ? $var : $existing_value;
+      }
+    }
+  }
+
+  /**
+   * Fill in minute values from existing events when an hour is being split.
+   *
+   * $existing_events must contain an existing event for the unit during either
+   * the same hour or day.
+   *
+   * @param array $existing_events
+   *   Existing event data from ::getEventData().
+   * @param array $itemized
+   *   The new event itemized. Values from existing overlapping events will be
+   *   inserted into it.
+   * @param int $value
+   *   The value of the event being added.
+   * @param int $unit_id
+   *   The unit the event being added.
+   * @param int $year
+   *   Year of the event.
+   * @param int $month
+   *   A month of the event.
+   * @param int $day
+   *   A day of the event.
+   * @param int $hour
+   *   An hour in which an existing event overlaps.
+   */
+  protected function itemizeSplitHour(array $existing_events, array &$itemized, $value, $unit_id, $year, $month, $day, $hour) {
+    if (isset($existing_events[$unit_id][EVENT::BAT_HOUR][$year][$month][$day][$hour])) {
+      $existing_value = $existing_events[$unit_id][EVENT::BAT_HOUR][$year][$month][$day][$hour];
+    }
+    else {
+      $existing_value = $existing_events[$unit_id][EVENT::BAT_DAY][$year][$month][$day];
+    }
+    if ($value === -1 && $existing_value > 0) {
+      $itemized_hour = &$itemized[Event::BAT_MINUTE][$year][$month][$day][$hour];
+      for ($minute = 0; $minute < 60; $minute++) {
+        $minute_key = 'm' . str_pad($minute, 2, '0', STR_PAD_LEFT);
+        $var = &$itemized_hour[$minute_key];
+        $var = isset($var) && $var != 0 ? $var : $existing_value;
+      }
+    }
+  }
 
 }

--- a/tests/CalendarTest.php
+++ b/tests/CalendarTest.php
@@ -889,4 +889,41 @@ class CalendarTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals($events[1][1]->getValue(), 11);
   }
 
+  public function testPartialOverlap() {
+    $u1 = new Unit(1, 0, array());
+    $units = array($u1);
+    $store = new SqlLiteDBStore($this->pdo, 'availability_event', SqlDBStore::BAT_STATE);
+    $calendar = new Calendar($units, $store);
+
+    $sd = new \DateTime('2020-07-12 00:00');
+    $ed = new \DateTime('2020-07-13 23:59');
+    // Base event to be split.
+    $sd1 = new \DateTime('2020-07-12 00:00');
+    $ed1 = new \DateTime('2020-07-13 23:59');
+    $e1s11 = new Event($sd1, $ed1, $u1, 11);
+    // Splits an existing day.
+    $sd2 = new \DateTime('2020-07-12 01:00');
+    $ed2 = new \DateTime('2020-07-12 03:00');
+    $e2s22 = new Event($sd2, $ed2, $u1, 22);
+    // Splits an existing hour when day is already split.
+    $sd3 = new \DateTime('2020-07-12 04:20');
+    $ed3 = new \DateTime('2020-07-12 04:25');
+    $e3s33 = new Event($sd3, $ed3, $u1, 33);
+    // Splits an hour in an existing day not previously split.
+    $sd4 = new \DateTime('2020-07-13 04:20');
+    $ed4 = new \DateTime('2020-07-13 04:25');
+    $e4s44 = new Event($sd4, $ed4, $u1, 44);
+
+    $calendar->addEvents(array($e1s11, $e2s22, $e3s33, $e4s44), Event::BAT_HOURLY);
+    $events = $calendar->getEvents($sd, $ed);
+
+    $this->assertEquals(11, $events[1][0]->getValue());
+    $this->assertEquals(22, $events[1][1]->getValue());
+    $this->assertEquals(11, $events[1][2]->getValue());
+    $this->assertEquals(33, $events[1][3]->getValue());
+    $this->assertEquals(11, $events[1][4]->getValue());
+    $this->assertEquals(44, $events[1][5]->getValue());
+    $this->assertEquals(11, $events[1][4]->getValue());
+  }
+
 }


### PR DESCRIPTION
When existing events are split by a newer event there will be gaps between the new ends of the existing events and the extent covered by the new event. This happens because the stores always overwrite entire days or hours in the database and the existing event values are not included in the itemization of the event being added.

This change introduces two helper methods to let the store fill in the gaps with representations of overlapping existing events before writing the new event to the database.

Fixed some broken type hints which helped with debugging this.